### PR TITLE
fix(ruffle): unpinned Ruffle CDN + preload in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Any other props are forwarded to the wrapper `<div>`.
 
 ## Playground
 
-➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-ruffle/tree/main/examples/stackblitz?file=src/main.tsx)** — minimal Vite + React + TS demo rendering a public-domain SWF via `<Flash />`.
+➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-ruffle/tree/main/examples/stackblitz)** — minimal Vite + React + TS demo rendering a public-domain SWF via `<Flash />`.
 
 Local copy: [`examples/stackblitz/`](./examples/stackblitz)
 

--- a/examples/stackblitz/README.md
+++ b/examples/stackblitz/README.md
@@ -4,7 +4,7 @@ A minimal Vite + React + TypeScript app that renders a Flash SWF using `<Flash /
 
 ## Open it live
 
-➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-ruffle/tree/main/examples/stackblitz?file=src/main.tsx)**
+➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-ruffle/tree/main/examples/stackblitz)**
 
 ## Run locally
 

--- a/examples/stackblitz/index.html
+++ b/examples/stackblitz/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>react-ruffle · StackBlitz demo</title>
+    <!--
+      Preload the Ruffle CDN script so `window.RufflePlayer` is defined before
+      the component mounts. react-ruffle <= 2.0.0 hardcodes a CDN URL pinned
+      to a version that no longer exists on npm; preloading bypasses its loader.
+    -->
+    <script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
     <style>
       body{font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;margin:0;padding:2rem;background:#1c0a02;color:#fed7aa}
       .wrap{max-width:600px;margin:2rem auto;text-align:center}

--- a/src/components/ruffle.tsx
+++ b/src/components/ruffle.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { RuffleConfig, RufflePlayerElement, RuffleProps } from "../types/ruffle";
 
-const RUFFLE_CDN = "https://unpkg.com/@ruffle-rs/ruffle@0.1.0";
+// Resolves to the latest published Ruffle build. Earlier versions of this
+// component pinned to @0.1.0, which the @ruffle-rs/ruffle npm package no
+// longer publishes (current versions are 0.2.0-nightly.*).
+const RUFFLE_CDN = "https://unpkg.com/@ruffle-rs/ruffle";
 
 // Global singleton: one script tag shared across all Ruffle instances
 let ruffleScriptPromise: Promise<void> | null = null;


### PR DESCRIPTION
## Summary

- The hardcoded `@ruffle-rs/ruffle@0.1.0` CDN URL returns 404 — that version no longer exists on npm (current versions are `0.2.0-nightly.*`). Drop the pin so the script tag resolves to the latest published Ruffle build.
- Add a `<script src="https://unpkg.com/@ruffle-rs/ruffle">` preload to the StackBlitz demo's `index.html` so `window.RufflePlayer` is defined before the component mounts — works around the broken loader in already-published versions (≤ 2.0.0).
- Drop the `?file=` query param from the README's "Open in StackBlitz" link; it triggers a "Could not find source file" warning in StackBlitz's editor.

## Test plan
- [x] StackBlitz demo loads the SWF without the "Failed to load Ruffle script" error
- [ ] After a new release, the source-level CDN fix is verified in production (no preload needed)